### PR TITLE
Do not check for stderr content on errors

### DIFF
--- a/PDFGenerator/PDFGenerator.php
+++ b/PDFGenerator/PDFGenerator.php
@@ -146,7 +146,7 @@ class PDFGenerator
      */
     private function checkStatus($status, $stdout, $stderr, $command)
     {
-        if (0 !== $status and '' !== $stderr) {
+        if (0 !== $status) {
             throw new \RuntimeException(sprintf(
                 'The exit status code \'%s\' says something went wrong:' . "\n"
                     . 'stderr: "%s"' . "\n"


### PR DESCRIPTION
A non-zero return code always signals an error, sometimes without an error message.
For example bash's code 127 means command not found but has no stderr message attached.
