### PR TITLE
Allow Controlling Command Environment

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -23,13 +23,13 @@ class Configuration implements ConfigurationInterface
     protected function getRootNode(TreeBuilder $treeBuilder, string $name)
     {
         if (\method_exists($treeBuilder, 'getRootNode')) {
- 
+
             return $treeBuilder->getRootNode();
         }
-        
+
         return $treeBuilder->root($name);
     }
-    
+
     /**
      * {@inheritDoc}
      */
@@ -39,6 +39,14 @@ class Configuration implements ConfigurationInterface
 
         $this->getRootNode($treeBuilder, 'spraed_pdf_generator')
             ->children()
+            ->arrayNode('command')
+                ->children()
+                    ->arrayNode('env')
+                        ->prototype('scalar')
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
             ->arrayNode('java')
             ->children()
             ->scalarNode('full_pathname')->defaultValue('')->end()

--- a/PDFGenerator/PDFGenerator.php
+++ b/PDFGenerator/PDFGenerator.php
@@ -102,7 +102,15 @@ final class PDFGenerator
             // stderr is a pipe that the child will write to
             2 => ['pipe', 'w']];
 
-        $process = proc_open($command, $descriptorspec, $pipes);
+        $commandOpts = $this->getOption('command');
+
+        $process = proc_open(
+            $command,
+            $descriptorspec,
+            $pipes,
+            null,
+            isset($commandOpts['env']) ? $commandOpts['env'] : null
+        );
 
         if (is_resource($process)) {
             // $pipes now looks like this:

--- a/README.markdown
+++ b/README.markdown
@@ -72,3 +72,19 @@ To define proper print css you might want to read into the w3.org's hints on tha
 [w3.org]: http://www.w3.org/TR/css3-page/
 [flyingsaucer]: https://github.com/flyingsaucerproject/flyingsaucer
 [spraed]: http://www.spraed.com
+
+Configuration
+-------------
+
+Example configuration options:
+
+        spraed_pdf_generator:
+            command:
+                env:
+                    FOO: BAR
+            java:
+                full_path: /path/to/java
+
+The command environment will add environment variables when running the Java
+application.
+

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Spraed\PDFGeneratorBundle\Tests\DependencyInjection;
+
+use PHPUnit\Framework\TestCase;
+use Spraed\PDFGeneratorBundle\DependencyInjection\Configuration;
+use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
+
+class ConfigurationTest extends TestCase
+{
+    use ConfigurationTestCaseTrait;
+
+    protected function getConfiguration()
+    {
+        return new Configuration();
+    }
+
+    public function testEmptyConfigurationIsValid()
+    {
+        $this->assertConfigurationIsValid(array());
+    }
+
+    public function testCommandEnvironmentCanBeSpecified()
+    {
+        $this->assertConfigurationIsValid(
+            array(
+                'spraed_pdf_generator' => array(
+                    'command' => array(
+                        'env' => array(
+                            'foo' => 'bar'
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    public function testJavaFullPathCanBeConfigured()
+    {
+        $this->assertConfigurationIsValid(
+            array(
+                'spraed_pdf_generator' => array(
+                    'java' => array(
+                        'full_pathname' => '/bin/java'
+                    )
+                )
+            )
+        );
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
 
     "require": {
         "php":                      "^7.2|^8.0",
-        "symfony/framework-bundle": "^4.0|^5.0"
+        "symfony/framework-bundle": "^4.0|^5.0",
+        "matthiasnoback/symfony-config-test": "^4.2"
     },
 
     "autoload": {


### PR DESCRIPTION
This allows controlling the environment variables set when running the Java command via configuration.

My use-case is I want to specify some additional Java options, so have...

```
spraed_pdf_generator:
    command:
        env:
            _JAVA_OPTIONS: "-Djava.protocol.handler.pkgs=org.xhtmlrenderer.protocols"
```

(To enable base64 support for img tags)
