### PR TITLE
Introduce PDFGenerator Interface

### DIFF
--- a/PDFGenerator/PDFGenerator.php
+++ b/PDFGenerator/PDFGenerator.php
@@ -5,7 +5,7 @@ namespace Spraed\PDFGeneratorBundle\PDFGenerator;
 use InvalidArgumentException;
 use RuntimeException;
 
-final class PDFGenerator
+final class PDFGenerator implements PDFGeneratorInterface
 {
     /**
      * @var array

--- a/PDFGenerator/PDFGeneratorInterface.php
+++ b/PDFGenerator/PDFGeneratorInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Spraed\PDFGeneratorBundle\PDFGenerator;
+
+interface PDFGeneratorInterface
+{
+    /** @param list<string> $fontPaths */
+    public function generatePDF(string $html, string $encoding = 'UTF-8', array $fontPaths = []): string;
+
+    /**
+     * @param list<string> $htmls
+     * @param list<string> $fontPaths
+     */
+    public function generatePDFs(array $htmls, string $encoding = 'UTF-8', array $fontPaths = []): string;
+
+    /** @param list<string> $fontPaths */
+    public function generate(string $htmlFile, string $encoding, string $pdfFile, array $fontPaths = []): string;
+
+    /** @return array{0: int, 1: string?, 2: string?} */
+    public function executeCommand(string $command): array;
+}


### PR DESCRIPTION
Now the PDFGenerator class is final it can no longer be effectively mocked (with tools like Prophecy), which causes problems in unit tests when this pattern is used to assert the services behaviour with other collaborators. This change introduces an interface which can be used to allow this kind of testing more easily.